### PR TITLE
Some classes have been marked as internals

### DIFF
--- a/src/Constants/ExceptionMessages.cs
+++ b/src/Constants/ExceptionMessages.cs
@@ -7,7 +7,7 @@ namespace DotEnv.Core;
 /// <summary>
 /// Represents the messages of an exception.
 /// </summary>
-public class ExceptionMessages
+internal class ExceptionMessages
 {
     public const string VariableNotSetMessage                   = "'{0}' is not set.";
     public const string DataSourceIsEmptyOrWhitespaceMessage    = "Data source is empty or consists only in whitespace.";

--- a/src/DotEnv.Core.csproj
+++ b/src/DotEnv.Core.csproj
@@ -28,4 +28,8 @@
     <None Include="..\LICENSE" Pack="True" PackagePath="" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="DotEnv.Core.Tests" />
+  </ItemGroup>
+  
 </Project>

--- a/src/Helpers/FormattingMessage.cs
+++ b/src/Helpers/FormattingMessage.cs
@@ -9,7 +9,7 @@ namespace DotEnv.Core;
 /// <summary>
 /// Define methods that format error messages.
 /// </summary>
-public class FormattingMessage
+internal class FormattingMessage
 {
     /// <summary>
     /// Formats an error message in case the local file is not present in any directory.


### PR DESCRIPTION
`ExceptionMessages` and `FormattingMessage` classes are useless for the client. They are implementation details of the library.