### PR TITLE
Added Invariant Culture that is culture-independent

### DIFF
--- a/src/Helpers/DotEnvHelper.cs
+++ b/src/Helpers/DotEnvHelper.cs
@@ -1,4 +1,6 @@
-﻿namespace DotEnv.Core;
+﻿using System.Globalization;
+
+namespace DotEnv.Core;
 
 /// <summary>
 /// Represents the Main Helper of DotEnv.
@@ -22,7 +24,7 @@ internal class DotEnvHelper
     public static object ChangeType(string value, Type conversionType)
         => conversionType.IsEnum ? 
                 Enum.Parse(conversionType, value, ignoreCase: true) : 
-                Convert.ChangeType(value, conversionType);
+                Convert.ChangeType(value, conversionType, CultureInfo.InvariantCulture);
 
     /// <summary>
     /// Checks if the passed elements are not null.


### PR DESCRIPTION
This culture indicates whether the invariant culture is being used to perform operations that do not depend on any specific culture.
This pull request was performed to ensure the use of floating point (`.`) regardless of the regional configuration of the system.

This PR is required to pass the tests of PR #127:https://github.com/MrDave1999/dotenv.core/blob/e7c8e04cecd056b702cf0bd61a76a137c2d43a74/tests/Reader/EnvAccessorExtensionsTests.cs#L49-L51.

