### PR TITLE
refactor: Remove the “Try/Catch” block found in the EnvLoader type

### DIFF
--- a/src/Loader/EnvLoader.HelperMethods.cs
+++ b/src/Loader/EnvLoader.HelperMethods.cs
@@ -66,12 +66,7 @@ public partial class EnvLoader
 
         string source = File.ReadAllText(fullPath, envFile.Encoding);
         _parser.FileName = envFile.Path;
-        try
-        {
-            _parser.Parse(source);
-        }
-        catch (ParserException) { }
-
+        _parser.ParseStart(source);
         return true;
     }
 

--- a/src/Parser/EnvParser.cs
+++ b/src/Parser/EnvParser.cs
@@ -51,15 +51,23 @@ public partial class EnvParser : IEnvParser
     {
         _ = dataSource ?? throw new ArgumentNullException(nameof(dataSource));
         result = ValidationResult;
+        ParseStart(dataSource);
+        CreateAndThrowParserException();
+        return _configuration.EnvVars;
+    }
 
+    /// <summary>
+    /// It contains the main logic of the key-value pair parsing algorithm.
+    /// </summary>
+    internal void ParseStart(string dataSource)
+    {
         if (string.IsNullOrWhiteSpace(dataSource))
         {
             ValidationResult.Add(errorMsg: FormatParserExceptionMessage(
-                DataSourceIsEmptyOrWhitespaceMessage, 
+                DataSourceIsEmptyOrWhitespaceMessage,
                 envFileName: FileName
             ));
-            CreateAndThrowParserException();
-            return _configuration.EnvVars;
+            return;
         }
 
         var lines = dataSource.Split(s_newLines, StringSplitOptions.None);
@@ -78,10 +86,10 @@ public partial class EnvParser : IEnvParser
             if (HasNoKeyValuePair(line))
             {
                 ValidationResult.Add(errorMsg: FormatParserExceptionMessage(
-                    LineHasNoKeyValuePairMessage, 
-                    actualValue: line, 
-                    lineNumber: currentLine, 
-                    column: 1, 
+                    LineHasNoKeyValuePairMessage,
+                    actualValue: line,
+                    lineNumber: currentLine,
+                    column: 1,
                     envFileName: FileName
                 ));
                 continue;
@@ -92,8 +100,8 @@ public partial class EnvParser : IEnvParser
             var key   = ExtractKey(line);
             var value = ExtractValue(line);
 
-            key   = RemovePrefixBeforeKey(key, ExportPrefix);
-            key   = TrimKey(key);
+            key = RemovePrefixBeforeKey(key, ExportPrefix);
+            key = TrimKey(key);
             if (IsQuoted(value))
                 value = RemoveQuotes(value);
             else if (IsMultiline(value))
@@ -114,8 +122,5 @@ public partial class EnvParser : IEnvParser
             else if (_configuration.OverwriteExistingVars)
                 EnvVarsProvider[key] = value;
         }
-
-        CreateAndThrowParserException();
-        return _configuration.EnvVars;
     }
 }


### PR DESCRIPTION
The purpose of PR is to remove this Try/Catch block:
https://github.com/MrDave1999/dotenv.core/blob/d6139e59bc1c5baf0888f5cf07cc5262157fb492/src/Loader/EnvLoader.HelperMethods.cs#L69-L73

**This Try/Catch block is bad for two reasons:**
- The real exception thrown is being hidden and absolutely nothing is done when the exception is caught.
  This only affects the readability of the code. It is not clear what this code does at first glance.
- It is not efficient. For example, if you read seven .env files and they all have a parse error, it will throw seven exceptions only to be caught and do nothing. This makes no sense, it wastes resources unnecessarily and is slower.

The real reason why this Try/Catch block was added was so as not to interrupt the execution flow of the .env file loader.
