### PR TITLE
refactor: Add formatting to an error message from EnvFileNames class

### DIFF
--- a/src/Common/FormattingMessage.cs
+++ b/src/Common/FormattingMessage.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Text;
 using static DotEnv.Core.DotEnvHelper;
-using static DotEnv.Core.EnvFileNames;
 
 namespace DotEnv.Core;
 
@@ -11,20 +10,6 @@ namespace DotEnv.Core;
 /// </summary>
 internal class FormattingMessage
 {
-    /// <summary>
-    /// Formats an error message in case the local file is not present in any directory.
-    /// </summary>
-    /// <param name="message">The message that describes the error.</param>
-    /// <param name="environmentName">The name of the current environment.</param>
-    /// <returns>A formatted error message.</returns>
-    public static string FormatLocalFileNotPresentMessage(string message = null, string environmentName = null)
-    {
-        message ??= "error: Any of these .env files must be present in the root directory of your project:";
-        return environmentName is not null ? 
-            $"{message} .env.{environmentName}.local or {EnvLocalName}" : 
-            $"{message} {EnvDevelopmentLocalName} or {EnvDevLocalName} or {EnvLocalName}";
-    }
-
     /// <summary>
     /// Formats an error message in case the parser encounters errors.
     /// </summary>

--- a/src/Loader/EnvFileNames.cs
+++ b/src/Loader/EnvFileNames.cs
@@ -7,9 +7,23 @@ namespace DotEnv.Core;
 internal class EnvFileNames
 {
     public const string EnvDevelopmentLocalName = ".env.development.local";
-    public const string EnvDevLocalName = ".env.dev.local";
-    public const string EnvLocalName = ".env.local";
-    public const string EnvDevelopmentName = ".env.development";
-    public const string EnvDevName = ".env.dev";
-    public const string EnvName = ".env";
+    public const string EnvDevLocalName         = ".env.dev.local";
+    public const string EnvLocalName            = ".env.local";
+    public const string EnvDevelopmentName      = ".env.development";
+    public const string EnvDevName              = ".env.dev";
+    public const string EnvName                 = ".env";
+
+    /// <summary>
+    /// Formats an error message in case the local file is not present in any directory.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="environmentName">The name of the current environment.</param>
+    /// <returns>A formatted error message.</returns>
+    public static string FormatLocalFileNotPresentMessage(string message = null, string environmentName = null)
+    {
+        message ??= "error: Any of these .env files must be present in the root directory of your project:";
+        return environmentName is not null ?
+            $"{message} .env.{environmentName}.local or {EnvLocalName}" :
+            $"{message} {EnvDevelopmentLocalName} or {EnvDevLocalName} or {EnvLocalName}";
+    }
 }

--- a/tests/Loader/EnvLoaderTests.LoadEnv.cs
+++ b/tests/Loader/EnvLoaderTests.LoadEnv.cs
@@ -230,6 +230,7 @@ public partial class EnvLoaderTests
         // Arrange
         Env.CurrentEnvironment = null;
         var loader = new EnvLoader();
+        var expectedErrorMessages = EnvFileNames.FormatLocalFileNotPresentMessage();
 
         // Act
         loader
@@ -240,7 +241,7 @@ public partial class EnvLoaderTests
         result.HasError().Should().BeTrue();
         result.Should().HaveCount(1);
         Env.CurrentEnvironment.Should().Be("development");
-        result.ErrorMessages.Should().Contain(FormatLocalFileNotPresentMessage());
+        result.ErrorMessages.Should().Contain(expectedErrorMessages);
     }
 
     [TestMethod]
@@ -249,6 +250,7 @@ public partial class EnvLoaderTests
         // Arrange
         var loader = new EnvLoader();
         Env.CurrentEnvironment = "test";
+        var expectedErrorMessages = EnvFileNames.FormatLocalFileNotPresentMessage(environmentName: Env.CurrentEnvironment);
 
         // Act
         loader
@@ -260,6 +262,6 @@ public partial class EnvLoaderTests
         result.Should().HaveCount(1);
         result.ErrorMessages
               .Should()
-              .Contain(FormatLocalFileNotPresentMessage(environmentName: Env.CurrentEnvironment));
+              .Contain(expectedErrorMessages);
     }
 }


### PR DESCRIPTION
The class called **EnvFileNames** contains the information required to perform the formatting of the error message, therefore, the **FormatLocalFileNotPresentMessage** method must be in EnvFileNames.
This follows the [information expert principle](https://en.wikipedia.org/wiki/GRASP_(object-oriented_design)).