### PR TITLE
refactor: Apply Result pattern to avoid returning null in private methods

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="IsExternalInit" Version="1.0.3" />
     <PackageVersion Include="DotEnv.Core" Version="3.0.0" />
     <PackageVersion Include="DotEnv.Core.Props" Version="1.0.1" />
     <PackageVersion Include="coverlet.msbuild" Version="3.1.2" />

--- a/src/Binder/EnvBinder.HelperMethods.cs
+++ b/src/Binder/EnvBinder.HelperMethods.cs
@@ -40,21 +40,20 @@ public partial class EnvBinder
     /// <param name="value">The value to convert.</param>
     /// <param name="conversionType">The type of object to return.</param>
     /// <returns>
-    /// A tuple with the converted value and 
-    /// a boolean value indicating whether the operation was successful.
+    /// A result with the converted value, otherwise returns a failure result.
     /// </returns>
-    private (object Value, bool Success) ChangeType(string value, Type conversionType)
+    private Result<object> ChangeType(string value, Type conversionType)
     {
         try
         {
             var convertedValue = DotEnvHelper.ChangeType(value, conversionType);
-            return (convertedValue, true);
+            return Result<object>.Success(convertedValue);
         }
         catch (Exception ex) 
             when (ex is FormatException || 
                   ex is ArgumentException)
         {
-            return (default, false);
+            return Result<object>.Failure();
         }
     }
 }

--- a/src/Binder/EnvBinder.cs
+++ b/src/Binder/EnvBinder.cs
@@ -84,10 +84,10 @@ public partial class EnvBinder : IEnvBinder
                 continue;
             }
 
-            var conversionResponse = ChangeType(retrievedValue, property.PropertyType);
-            if (conversionResponse.Success)
+            Result<object> conversionResult = ChangeType(retrievedValue, property.PropertyType);
+            if (conversionResult.IsSuccess)
             {
-                property.SetValue(settings, conversionResponse.Value);
+                property.SetValue(settings, conversionResult.Value);
                 continue;
             }
             

--- a/src/Common/Results/ResultOfT.cs
+++ b/src/Common/Results/ResultOfT.cs
@@ -1,0 +1,42 @@
+﻿namespace DotEnv.Core;
+
+/// <summary>
+/// Represents the result of an operation.
+/// </summary>
+/// <typeparam name="TValue">A value associated to the result.</typeparam>
+internal readonly ref struct Result<TValue>
+{
+    /// <summary>
+    /// Gets the value associated with the result.
+    /// </summary>
+    public TValue Value { get; init; } = default;
+
+    /// <summary>
+    /// A value indicating that the result was successful.
+    /// </summary>
+    public bool IsSuccess { get; init; } = true;
+
+    /// <summary>
+    /// A value that indicates that the result was a failure.
+    /// </summary>
+    public bool IsFailed => !IsSuccess;
+
+    public Result() { }
+
+    /// <summary>
+    /// Represents a successful operation and accepts a values as the result of the operation.
+    /// </summary>
+    /// <param name="value">The value to be set.</param>
+    public static Result<TValue> Success(TValue value) => new()
+    {
+        Value = value
+    };
+
+    /// <summary>
+    /// Represents an error that occurred during the execution of a operation.
+    /// </summary>
+    public static Result<TValue> Failure() => new()
+    {
+        IsSuccess = false
+    };
+}

--- a/src/DotEnv.Core.csproj
+++ b/src/DotEnv.Core.csproj
@@ -34,6 +34,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="IsExternalInit">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Update="Common\Resources\ExceptionMessages.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/src/Parser/EnvParser.HelperMethods.cs
+++ b/src/Parser/EnvParser.HelperMethods.cs
@@ -263,9 +263,10 @@ public partial class EnvParser
     /// <param name="value">The value of a key.</param>
     /// <exception cref="ArgumentNullException">lines or value is <c>null</c>.</exception>
     /// <returns>
-    /// A string with the values separated by a new line, or <c>null</c> if the line has no end quote.
+    /// A result that contains the values separated by a new line, 
+    /// or returns a failure result if the line has no end quote.
     /// </returns>
-    private string GetValuesMultilines(string[] lines, ref int index, string value)
+    private Result<string> GetValuesMultilines(string[] lines, ref int index, string value)
     {
         _ = lines ?? throw new ArgumentNullException(nameof(lines));
         _ = value ?? throw new ArgumentNullException(nameof(value));
@@ -284,7 +285,7 @@ public partial class EnvParser
             {
                 var lineWithoutQuote = line.Substring(0, trimmedLine.Length - 1);
                 value = $"{value}\n{lineWithoutQuote}";
-                return value;
+                return Result<string>.Success(value);
             }
             value = $"{value}\n{line}";
         }
@@ -295,7 +296,7 @@ public partial class EnvParser
             column: 1,
             envFileName: FileName
         ));
-        return null;
+        return Result<string>.Failure();
     }
 
     /// <summary>

--- a/src/Parser/EnvParser.cs
+++ b/src/Parser/EnvParser.cs
@@ -103,15 +103,22 @@ public partial class EnvParser : IEnvParser
             key = RemovePrefixBeforeKey(key, ExportPrefix);
             key = TrimKey(key);
             if (IsQuoted(value))
+            {
                 value = RemoveQuotes(value);
+            }
             else if (IsMultiline(value))
             {
-                value = GetValuesMultilines(lines, ref i, ConcatCommentWithValue(value, removedComment));
-                if (value is null)
+                var concatenatedValue = ConcatCommentWithValue(value, removedComment);
+                Result<string> multilineResult = GetValuesMultilines(lines, ref i, concatenatedValue);
+                if (multilineResult.IsFailed)
                     continue;
+
+                value = multilineResult.Value;
             }
             else
+            {
                 value = TrimValue(value);
+            }
             value = ConvertStringEmptyToWhitespace(value);
 
             var retrievedValue = EnvVarsProvider[key];


### PR DESCRIPTION
This pattern has been applied for two reasons:
- It makes the producer code more expressive because it uses factory methods such as **Success and Failure** instead of returning a null value.
- It makes the consumer code more expressive because it uses properties such as **IsSuccess and IsFailed** instead of performing a null check.

*Expressive code means that it indicates its own intention so that it is clear at first glance.*

### Performance
Performance will not be affected because the "ref struct" type is used.
See https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/ref-struct
> You can use the ref modifier in the declaration of a [structure type](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/struct). Instances of a ref struct type are allocated on the stack and can't escape to the managed heap.

This means that there will be no load on the garbage collector, reducing the memory reallocations on the heap.