### PR TITLE
refactor: Create guard clauses

### DIFF
--- a/plugins/Microsoft.Extensions.DI/src/ServiceCollectionExtensions.cs
+++ b/plugins/Microsoft.Extensions.DI/src/ServiceCollectionExtensions.cs
@@ -28,7 +28,9 @@ public static partial class ServiceCollectionExtensions
     /// <returns>An instance that allows access to the environment variables.</returns>
     public static IEnvReader AddDotEnv(this IServiceCollection services, params string[] paths)
     {
-        _ = services ?? throw new ArgumentNullException(nameof(services));
+        ThrowHelper.ThrowIfNull(services, nameof(services));
+        ThrowHelper.ThrowIfNull(paths, nameof(paths));
+        ThrowHelper.ThrowIfEmptyCollection(paths, nameof(paths));
         var envVars = Load(paths);
         return services.AddEnvReader(envVars);
     }
@@ -57,7 +59,9 @@ public static partial class ServiceCollectionExtensions
     public static TSettings AddDotEnv<TSettings>(this IServiceCollection services, params string[] paths) 
         where TSettings : class, new()
     {
-        _ = services ?? throw new ArgumentNullException(nameof(services));
+        ThrowHelper.ThrowIfNull(services, nameof(services));
+        ThrowHelper.ThrowIfNull(paths, nameof(paths));
+        ThrowHelper.ThrowIfEmptyCollection(paths, nameof(paths));
         var envVars = Load(paths);
         return services.AddTSettings<TSettings>(envVars);
     }
@@ -73,7 +77,7 @@ public static partial class ServiceCollectionExtensions
     /// <returns>An instance that allows access to the environment variables.</returns>
     public static IEnvReader AddCustomEnv(this IServiceCollection services, string basePath = null, string environmentName = null)
     {
-        _ = services ?? throw new ArgumentNullException(nameof(services));
+        ThrowHelper.ThrowIfNull(services, nameof(services));
         var envVars = LoadEnv(basePath, environmentName);
         return services.AddEnvReader(envVars);
     }
@@ -91,7 +95,7 @@ public static partial class ServiceCollectionExtensions
     public static TSettings AddCustomEnv<TSettings>(this IServiceCollection services, string basePath = null, string environmentName = null) 
         where TSettings : class, new()
     {
-        _ = services ?? throw new ArgumentNullException(nameof(services));
+        ThrowHelper.ThrowIfNull(services, nameof(services));
         var envVars = LoadEnv(basePath, environmentName);
         return services.AddTSettings<TSettings>(envVars);
     }

--- a/src/Common/Env.cs
+++ b/src/Common/Env.cs
@@ -56,7 +56,7 @@ public static class Env
     /// <exception cref="ArgumentNullException"><c>environmentName</c> is <c>null</c>.</exception>
     public static bool IsEnvironment(string environmentName)
     {
-        _ = environmentName ?? throw new ArgumentNullException(nameof(environmentName));
+        ThrowHelper.ThrowIfNull(environmentName, nameof(environmentName));
         return string.Equals(CurrentEnvironment, environmentName, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Common/ThrowHelper.cs
+++ b/src/Common/ThrowHelper.cs
@@ -1,0 +1,57 @@
+﻿using static DotEnv.Core.ExceptionMessages;
+
+namespace DotEnv.Core;
+
+/// <summary>
+/// Helper methods to efficiently throw exceptions.
+/// </summary>
+internal class ThrowHelper
+{
+    /// <summary>
+    /// Throws an <see cref="ArgumentNullException"/> if <c>argument</c> is <c>null</c>.
+    /// </summary>
+    /// <param name="argument">
+    /// The reference type argument to validate as non-null.
+    /// </param>
+    /// <param name="paramName">
+    /// The name of the parameter with which argument corresponds.
+    /// </param>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static void ThrowIfNull(object argument, string paramName)
+    {
+        if(argument is null)
+            throw new ArgumentNullException(paramName);
+    }
+
+    /// <summary>
+    /// Throws an exception if <c>argument</c> is null, empty, or consists only of white-space characters.
+    /// </summary>
+    /// <param name="argument">
+    /// The string argument to validate.
+    /// </param>
+    /// <param name="paramName">
+    /// The name of the parameter with which argument corresponds.
+    /// </param>
+    /// <exception cref="ArgumentException"></exception>
+    public static void ThrowIfNullOrWhiteSpace(string argument, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(argument))
+            throw new ArgumentException(ArgumentIsNullOrWhiteSpaceMessage, paramName);
+    }
+
+    /// <summary>
+    /// Throws an exception if the <c>argument</c> is an empty collection.
+    /// </summary>
+    /// <param name="argument">
+    /// The collection argument to validate.
+    /// </param>
+    /// <param name="paramName">
+    /// The name of the parameter with which argument corresponds.
+    /// </param>
+    /// <exception cref="ArgumentException"></exception>
+    public static void ThrowIfEmptyCollection(IEnumerable<string> argument, string paramName)
+    {
+        if (argument.IsEmpty())
+            throw new ArgumentException(LengthOfParamsListIsZeroMessage, paramName);
+    }
+}

--- a/src/DotEnv.Core.csproj
+++ b/src/DotEnv.Core.csproj
@@ -31,6 +31,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="DotEnv.Core.Tests" />
+    <InternalsVisibleTo Include="DotEnv.Extensions.Microsoft.DI" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Loader/EnvLoader.ConfigurationMethods.cs
+++ b/src/Loader/EnvLoader.ConfigurationMethods.cs
@@ -12,7 +12,7 @@ public partial class EnvLoader
     /// <inheritdoc />
     public IEnvLoader SetDefaultEnvFileName(string envFileName)
     {
-        _ = envFileName ?? throw new ArgumentNullException(nameof(envFileName));
+        ThrowHelper.ThrowIfNull(envFileName, nameof(envFileName));
         _configuration.DefaultEnvFileName = envFileName;
         return this;
     }
@@ -20,7 +20,7 @@ public partial class EnvLoader
     /// <inheritdoc />
     public IEnvLoader SetBasePath(string basePath)
     {
-        _ = basePath ?? throw new ArgumentNullException(nameof(basePath));
+        ThrowHelper.ThrowIfNull(basePath, nameof(basePath));
         _configuration.BasePath = basePath;
         return this;
     }
@@ -28,10 +28,8 @@ public partial class EnvLoader
     /// <inheritdoc />
     public IEnvLoader AddEnvFiles(params string[] paths)
     {
-        _ = paths ?? throw new ArgumentNullException(nameof(paths));
-        if (paths.IsEmpty())
-            throw new ArgumentException(LengthOfParamsListIsZeroMessage, nameof(paths));
-
+        ThrowHelper.ThrowIfNull(paths, nameof(paths));
+        ThrowHelper.ThrowIfEmptyCollection(paths, nameof(paths));
         foreach (string path in paths)
             AddEnvFile(path);
         return this;
@@ -48,7 +46,7 @@ public partial class EnvLoader
     /// <inheritdoc />
     public IEnvLoader AddEnvFile(string path, Encoding encoding, bool optional)
     {
-        _ = path ?? throw new ArgumentNullException(nameof(path));
+        ThrowHelper.ThrowIfNull(path, nameof(path));
         _configuration.EnvFiles.Add(new EnvFile { Path = path, Encoding = encoding, Optional = optional});
         return this;
     }
@@ -60,8 +58,8 @@ public partial class EnvLoader
     /// <inheritdoc />
     public IEnvLoader AddEnvFile(string path, string encodingName, bool optional)
     {
-        _ = path ?? throw new ArgumentNullException(nameof(path));
-        _ = encodingName ?? throw new ArgumentNullException(nameof(encodingName));
+        ThrowHelper.ThrowIfNull(path, nameof(path));
+        ThrowHelper.ThrowIfNull(encodingName, nameof(encodingName));
         try
         {
             AddEnvFile(path, Encoding.GetEncoding(encodingName), optional);
@@ -80,7 +78,7 @@ public partial class EnvLoader
     /// <inheritdoc />
     public IEnvLoader SetEncoding(Encoding encoding)
     {
-        _ = encoding ?? throw new ArgumentNullException(nameof(encoding));
+        ThrowHelper.ThrowIfNull(encoding, nameof(encoding));
         _configuration.Encoding = encoding;
         return this;
     }
@@ -109,10 +107,8 @@ public partial class EnvLoader
     /// <inheritdoc />
     public IEnvLoader SetEnvironmentName(string envName)
     {
-        _ = envName ?? throw new ArgumentNullException(nameof(envName));
-        if (string.IsNullOrWhiteSpace(envName))
-            throw new ArgumentException(ArgumentIsNullOrWhiteSpaceMessage, nameof(envName));
-
+        ThrowHelper.ThrowIfNull(envName, nameof(envName));
+        ThrowHelper.ThrowIfNullOrWhiteSpace(envName, nameof(envName));
         _configuration.EnvironmentName = envName;
         return this;
     }

--- a/src/Loader/EnvLoader.HelperMethods.cs
+++ b/src/Loader/EnvLoader.HelperMethods.cs
@@ -16,7 +16,7 @@ public partial class EnvLoader
     /// <exception cref="ArgumentNullException"><c>envFile</c> is <c>null</c>.</exception>
     private void CheckIfEnvFileNotExistsAndIsNotOptional(EnvFile envFile)
     {
-        _ = envFile ?? throw new ArgumentNullException(nameof(envFile));
+        ThrowHelper.ThrowIfNull(envFile, nameof(envFile));
         if (!envFile.Exists && !envFile.Optional)
             _validationResult.Add(errorMsg: string.Format(FileNotFoundMessage, envFile.Path));
     }
@@ -61,7 +61,7 @@ public partial class EnvLoader
     /// <returns>true if the .env file exists, otherwise false.</returns>
     private bool ReadAndParse(EnvFile envFile)
     {
-        _ = envFile ?? throw new ArgumentNullException(nameof(envFile));
+        ThrowHelper.ThrowIfNull(envFile, nameof(envFile));
         Result<string> result;
         if (_configuration.SearchParentDirectories)
             result = GetEnvFilePath(envFile.Path);
@@ -94,7 +94,7 @@ public partial class EnvLoader
     /// <inheritdoc cref="Load()" path="/remarks" />
     private Result<string> GetEnvFilePath(string envFileName)
     {
-        _ = envFileName ?? throw new ArgumentNullException(nameof(envFileName));
+        ThrowHelper.ThrowIfNull(envFileName, nameof(envFileName));
         string path;
         if (Path.IsPathRooted(envFileName))
         {
@@ -122,7 +122,7 @@ public partial class EnvLoader
     /// <exception cref="ArgumentNullException"><c>envFile</c> is <c>null</c>.</exception>
     private void SetConfigurationEnvFile(EnvFile envFile)
     {
-        _ = envFile ?? throw new ArgumentNullException(nameof(envFile));
+        ThrowHelper.ThrowIfNull(envFile, nameof(envFile));
         if (!Path.HasExtension(envFile.Path))
             envFile.Path = Path.Combine(envFile.Path, _configuration.DefaultEnvFileName);
 
@@ -138,7 +138,7 @@ public partial class EnvLoader
     /// <exception cref="ArgumentNullException"><c>envFilesNames</c> is <c>null</c>.</exception>
     private void AddOptionalEnvFiles(params string[] envFilesNames)
     {
-        _ = envFilesNames ?? throw new ArgumentNullException(nameof(envFilesNames));
+        ThrowHelper.ThrowIfNull(envFilesNames, nameof(envFilesNames));
         foreach (string envFileName in envFilesNames)
             _configuration.EnvFiles.Add(new EnvFile { Path = envFileName, Optional = true });
     }

--- a/src/Parser/EnvParser.HelperMethods.cs
+++ b/src/Parser/EnvParser.HelperMethods.cs
@@ -28,7 +28,7 @@ public partial class EnvParser
     /// <returns><c>true</c> if the line is a comment, otherwise <c>false</c>.</returns>
     private bool IsComment(string line)
     {
-        _ = line ?? throw new ArgumentNullException(nameof(line));
+        ThrowHelper.ThrowIfNull(line, nameof(line));
         line = _configuration.TrimStartComments ? line.TrimStart() : line;
         return line[0] == _configuration.CommentChar;
     }
@@ -42,7 +42,7 @@ public partial class EnvParser
     /// <returns>A string without the inline comment.</returns>
     private string RemoveInlineComment(string line, out string comment)
     {
-        _ = line ?? throw new ArgumentNullException(nameof(line));
+        ThrowHelper.ThrowIfNull(line, nameof(line));
         var substrings = line.Split(_configuration.InlineCommentChars, MaxCount, StringSplitOptions.None);
         comment = substrings.Length == 1 ? null : substrings[1];
         return substrings[0];
@@ -68,7 +68,7 @@ public partial class EnvParser
     /// </returns>
     private string TrimKey(string key)
     {
-        _ = key ?? throw new ArgumentNullException(nameof(key));
+        ThrowHelper.ThrowIfNull(key, nameof(key));
         key = _configuration.TrimStartKeys ? key.TrimStart() : key;
         key = _configuration.TrimEndKeys ? key.TrimEnd() : key;
         return key;
@@ -85,7 +85,7 @@ public partial class EnvParser
     /// </returns>
     private string TrimValue(string value)
     {
-        _ = value ?? throw new ArgumentNullException(nameof(value));
+        ThrowHelper.ThrowIfNull(value, nameof(value));
         value = _configuration.TrimStartValues ? value.TrimStart() : value;
         value = _configuration.TrimEndValues ? value.TrimEnd() : value;
         return value;
@@ -99,7 +99,7 @@ public partial class EnvParser
     /// <returns>The key extracted.</returns>
     private string ExtractKey(string line)
     {
-        _ = line ?? throw new ArgumentNullException(nameof(line));
+        ThrowHelper.ThrowIfNull(line, nameof(line));
         string key = line.Split(_configuration.DelimiterKeyValuePair, MaxCount)[0];
         return key;
     }
@@ -112,7 +112,7 @@ public partial class EnvParser
     /// <returns>The value extracted.</returns>
     private string ExtractValue(string line)
     {
-        _ = line ?? throw new ArgumentNullException(nameof(line));
+        ThrowHelper.ThrowIfNull(line, nameof(line));
         string value = line.Split(_configuration.DelimiterKeyValuePair, MaxCount)[1];
         return value;
     }
@@ -125,7 +125,7 @@ public partial class EnvParser
     /// <returns><c>true</c> if the line has no the key-value pair, otherwise <c>false</c>.</returns>
     private bool HasNoKeyValuePair(string line)
     {
-        _ = line ?? throw new ArgumentNullException(nameof(line));
+        ThrowHelper.ThrowIfNull(line, nameof(line));
         var keyValuePair = line.Split(_configuration.DelimiterKeyValuePair, MaxCount);
         return keyValuePair.Length != 2 || string.IsNullOrWhiteSpace(keyValuePair[0]);
     }
@@ -148,7 +148,7 @@ public partial class EnvParser
     /// <returns>A string with each environment variable replaced by its value.</returns>
     private string ExpandEnvironmentVariables(string name, int currentLine)
     {
-        _ = name ?? throw new ArgumentNullException(nameof(name));
+        ThrowHelper.ThrowIfNull(name, nameof(name));
         var pattern = @"\$\{([^}]*)\}";
         name = Regex.Replace(name, pattern, match =>
         {
@@ -197,7 +197,7 @@ public partial class EnvParser
     /// <returns><c>true</c> if the text is quoted, or <c>false</c>.</returns>
     private bool IsQuoted(string text)
     {
-        _ = text ?? throw new ArgumentNullException(nameof(text));
+        ThrowHelper.ThrowIfNull(text, nameof(text));
         text = text.Trim();
         if(text.Length <= 1)
             return false;
@@ -213,7 +213,7 @@ public partial class EnvParser
     /// <returns>A string without single or double quotes.</returns>
     private string RemoveQuotes(string text)
     {
-        _ = text ?? throw new ArgumentNullException(nameof(text));
+        ThrowHelper.ThrowIfNull(text, nameof(text));
         return text.Trim().Trim([SingleQuote, DoubleQuote]);
     }
 
@@ -226,8 +226,8 @@ public partial class EnvParser
     /// <returns>A key without the prefix.</returns>
     private string RemovePrefixBeforeKey(string key, string prefix)
     {
-        _ = key    ?? throw new ArgumentNullException(nameof(key));
-        _ = prefix ?? throw new ArgumentNullException(nameof(prefix));
+        ThrowHelper.ThrowIfNull(key, nameof(key));
+        ThrowHelper.ThrowIfNull(prefix, nameof(prefix));
         var aux = key;
         key = key.TrimStart();
         return key.IndexOf(prefix) == 0 ? key.Remove(0, prefix.Length) : aux;
@@ -243,7 +243,7 @@ public partial class EnvParser
     /// </returns>
     private bool IsMultiline(string value)
     {
-        _ = value ?? throw new ArgumentNullException(nameof(value));
+        ThrowHelper.ThrowIfNull(value, nameof(value));
         value = value.Trim();
         if(value.Length == 0)
             return false;
@@ -268,8 +268,8 @@ public partial class EnvParser
     /// </returns>
     private Result<string> GetValuesMultilines(string[] lines, ref int index, string value)
     {
-        _ = lines ?? throw new ArgumentNullException(nameof(lines));
-        _ = value ?? throw new ArgumentNullException(nameof(value));
+        ThrowHelper.ThrowIfNull(lines, nameof(lines));
+        ThrowHelper.ThrowIfNull(value, nameof(value));
         value = value.TrimStart();
         // Double or single-quoted.
         char quoteChar = value[0];

--- a/src/Parser/EnvParser.cs
+++ b/src/Parser/EnvParser.cs
@@ -49,7 +49,7 @@ public partial class EnvParser : IEnvParser
     /// <inheritdoc />
     public IEnvironmentVariablesProvider Parse(string dataSource, out EnvValidationResult result)
     {
-        _ = dataSource ?? throw new ArgumentNullException(nameof(dataSource));
+        ThrowHelper.ThrowIfNull(dataSource, nameof(dataSource));
         result = ValidationResult;
         ParseStart(dataSource);
         ThrowParserExceptionIfErrorsExist();

--- a/src/Providers/DefaultEnvironmentProvider.cs
+++ b/src/Providers/DefaultEnvironmentProvider.cs
@@ -16,7 +16,7 @@ internal class DefaultEnvironmentProvider : IEnvironmentVariablesProvider
         get => Environment.GetEnvironmentVariable(variable);
         set
         {
-            _ = variable ?? throw new ArgumentNullException(nameof(variable));
+            ThrowHelper.ThrowIfNull(variable, nameof(variable));
             Environment.SetEnvironmentVariable(variable, value);
         }
     }

--- a/src/Providers/DictionaryProvider.cs
+++ b/src/Providers/DictionaryProvider.cs
@@ -22,7 +22,7 @@ internal class DictionaryProvider : IEnvironmentVariablesProvider
         }
         set
         {
-            _ = variable ?? throw new ArgumentNullException(nameof(variable));
+            ThrowHelper.ThrowIfNull(variable, nameof(variable));
             _keyValuePairs[variable] = value;
         }
     }

--- a/src/Reader/EnvReader.Try.cs
+++ b/src/Reader/EnvReader.Try.cs
@@ -12,7 +12,7 @@ public partial class EnvReader
     /// <inheritdoc />
     public virtual bool TryGetStringValue(string variable, out string value)
     {
-        _ = variable ?? throw new ArgumentNullException(nameof(variable));
+        ThrowHelper.ThrowIfNull(variable, nameof(variable));
         var retrievedValue = _envVars[variable];
         if(retrievedValue is null)
         {
@@ -26,7 +26,7 @@ public partial class EnvReader
     /// <inheritdoc />
     public virtual bool TryGetBoolValue(string variable, out bool value)
     {
-        _ = variable ?? throw new ArgumentNullException(nameof(variable));
+        ThrowHelper.ThrowIfNull(variable, nameof(variable));
         var retrievedValue = _envVars[variable];
         if (retrievedValue is null)
         {
@@ -40,7 +40,7 @@ public partial class EnvReader
     /// <inheritdoc />
     public virtual bool TryGetByteValue(string variable, out byte value)
     {
-        _ = variable ?? throw new ArgumentNullException(nameof(variable));
+        ThrowHelper.ThrowIfNull(variable, nameof(variable));
         var retrievedValue = _envVars[variable];
         if (retrievedValue is null)
         {
@@ -54,7 +54,7 @@ public partial class EnvReader
     /// <inheritdoc />
     public virtual bool TryGetSByteValue(string variable, out sbyte value)
     {
-        _ = variable ?? throw new ArgumentNullException(nameof(variable));
+        ThrowHelper.ThrowIfNull(variable, nameof(variable));
         var retrievedValue = _envVars[variable];
         if (retrievedValue is null)
         {
@@ -68,7 +68,7 @@ public partial class EnvReader
     /// <inheritdoc />
     public virtual bool TryGetCharValue(string variable, out char value)
     {
-        _ = variable ?? throw new ArgumentNullException(nameof(variable));
+        ThrowHelper.ThrowIfNull(variable, nameof(variable));
         var retrievedValue = _envVars[variable];
         if (retrievedValue is null)
         {
@@ -82,7 +82,7 @@ public partial class EnvReader
     /// <inheritdoc />
     public virtual bool TryGetIntValue(string variable, out int value)
     {
-        _ = variable ?? throw new ArgumentNullException(nameof(variable));
+        ThrowHelper.ThrowIfNull(variable, nameof(variable));
         var retrievedValue = _envVars[variable];
         if (retrievedValue is null)
         {
@@ -96,7 +96,7 @@ public partial class EnvReader
     /// <inheritdoc />
     public virtual bool TryGetUIntValue(string variable, out uint value)
     {
-        _ = variable ?? throw new ArgumentNullException(nameof(variable));
+        ThrowHelper.ThrowIfNull(variable, nameof(variable));
         var retrievedValue = _envVars[variable];
         if (retrievedValue is null)
         {
@@ -110,7 +110,7 @@ public partial class EnvReader
     /// <inheritdoc />
     public virtual bool TryGetLongValue(string variable, out long value)
     {
-        _ = variable ?? throw new ArgumentNullException(nameof(variable));
+        ThrowHelper.ThrowIfNull(variable, nameof(variable));
         var retrievedValue = _envVars[variable];
         if (retrievedValue is null)
         {
@@ -124,7 +124,7 @@ public partial class EnvReader
     /// <inheritdoc />
     public virtual bool TryGetULongValue(string variable, out ulong value)
     {
-        _ = variable ?? throw new ArgumentNullException(nameof(variable));
+        ThrowHelper.ThrowIfNull(variable, nameof(variable));
         var retrievedValue = _envVars[variable];
         if (retrievedValue is null)
         {
@@ -138,7 +138,7 @@ public partial class EnvReader
     /// <inheritdoc />
     public virtual bool TryGetShortValue(string variable, out short value)
     {
-        _ = variable ?? throw new ArgumentNullException(nameof(variable));
+        ThrowHelper.ThrowIfNull(variable, nameof(variable));
         var retrievedValue = _envVars[variable];
         if (retrievedValue is null)
         {
@@ -152,7 +152,7 @@ public partial class EnvReader
     /// <inheritdoc />
     public virtual bool TryGetUShortValue(string variable, out ushort value)
     {
-        _ = variable ?? throw new ArgumentNullException(nameof(variable));
+        ThrowHelper.ThrowIfNull(variable, nameof(variable));
         var retrievedValue = _envVars[variable];
         if (retrievedValue is null)
         {
@@ -166,7 +166,7 @@ public partial class EnvReader
     /// <inheritdoc />
     public virtual bool TryGetDecimalValue(string variable, out decimal value)
     {
-        _ = variable ?? throw new ArgumentNullException(nameof(variable));
+        ThrowHelper.ThrowIfNull(variable, nameof(variable));
         var retrievedValue = _envVars[variable];
         if (retrievedValue is null)
         {
@@ -180,7 +180,7 @@ public partial class EnvReader
     /// <inheritdoc />
     public virtual bool TryGetDoubleValue(string variable, out double value)
     {
-        _ = variable ?? throw new ArgumentNullException(nameof(variable));
+        ThrowHelper.ThrowIfNull(variable, nameof(variable));
         var retrievedValue = _envVars[variable];
         if (retrievedValue is null)
         {
@@ -194,7 +194,7 @@ public partial class EnvReader
     /// <inheritdoc />
     public virtual bool TryGetFloatValue(string variable, out float value)
     {
-        _ = variable ?? throw new ArgumentNullException(nameof(variable));
+        ThrowHelper.ThrowIfNull(variable, nameof(variable));
         var retrievedValue = _envVars[variable];
         if (retrievedValue is null)
         {

--- a/src/Reader/EnvReader.cs
+++ b/src/Reader/EnvReader.cs
@@ -37,7 +37,7 @@ public partial class EnvReader : IEnvReader
     /// <inheritdoc />
     public virtual bool HasValue(string variable)
     {
-        _ = variable ?? throw new ArgumentNullException(nameof(variable));
+        ThrowHelper.ThrowIfNull(variable, nameof(variable));
         var retrievedValue = _envVars[variable];
         return retrievedValue is not null;
     }

--- a/src/Validator/EnvValidator.cs
+++ b/src/Validator/EnvValidator.cs
@@ -62,10 +62,8 @@ public class EnvValidator : IEnvValidator
     /// <inheritdoc />
     public IEnvValidator SetRequiredKeys(params string[] keys)
     {
-        _ = keys ?? throw new ArgumentNullException(nameof(keys));
-        if (keys.IsEmpty())
-            throw new ArgumentException(LengthOfParamsListIsZeroMessage, nameof(keys));
-
+        ThrowHelper.ThrowIfNull(keys, nameof(keys));
+        ThrowHelper.ThrowIfEmptyCollection(keys, nameof(keys));
         _configuration.RequiredKeys = keys;
         return this;
     }
@@ -87,7 +85,7 @@ public class EnvValidator : IEnvValidator
     /// <inheritdoc />
     public IEnvValidator SetRequiredKeys(Type keysType)
     {
-        _ = keysType ?? throw new ArgumentNullException(nameof(keysType));
+        ThrowHelper.ThrowIfNull(keysType, nameof(keysType));
         var readablePropertyNames =
             from propertyInfo in keysType.GetProperties()
             where propertyInfo.CanRead && propertyInfo.PropertyType == typeof(string)


### PR DESCRIPTION
ThrowHelper API has been created for several reasons:
- It makes the consumer code read in a natural language, so the code is clear at first glance.
- It reduces repetitive null checks, so it can be encapsulated in helper methods.
- Reduces the size of the code generated by the JIT. 
  See https://learn.microsoft.com/en-us/dotnet/communitytoolkit/diagnostics/throwhelper#technical-details