### PR TITLE
fix: Add null checks in the constructor of some classes

### DIFF
--- a/src/Binder/EnvBinder.cs
+++ b/src/Binder/EnvBinder.cs
@@ -31,8 +31,10 @@ public partial class EnvBinder : IEnvBinder
     /// Initializes a new instance of the <see cref="EnvBinder" /> class with environment variables provider.
     /// </summary>
     /// <param name="provider">The environment variables provider.</param>
+    /// <exception cref="ArgumentNullException"><c>provider</c> is <c>null</c>.</exception>
     public EnvBinder(IEnvironmentVariablesProvider provider)
     {
+        ThrowHelper.ThrowIfNull(provider, nameof(provider));
         _configuration.EnvVars = provider;
     }
 

--- a/src/Reader/EnvReader.cs
+++ b/src/Reader/EnvReader.cs
@@ -29,8 +29,10 @@ public partial class EnvReader : IEnvReader
     /// Initializes a new instance of the <see cref="EnvReader" /> class with environment variables provider.
     /// </summary>
     /// <param name="provider">The environment variables provider.</param>
+    /// <exception cref="ArgumentNullException"><c>provider</c> is <c>null</c>.</exception>
     public EnvReader(IEnvironmentVariablesProvider provider)
     {
+        ThrowHelper.ThrowIfNull(provider, nameof(provider));
         _envVars = provider;
     }
 

--- a/src/Validator/EnvValidator.cs
+++ b/src/Validator/EnvValidator.cs
@@ -32,8 +32,10 @@ public class EnvValidator : IEnvValidator
     /// Initializes a new instance of the <see cref="EnvValidator" /> class with environment variables provider.
     /// </summary>
     /// <param name="provider">The environment variables provider.</param>
+    /// <exception cref="ArgumentNullException"><c>provider</c> is <c>null</c>.</exception>
     public EnvValidator(IEnvironmentVariablesProvider provider)
     {
+        ThrowHelper.ThrowIfNull(provider, nameof(provider));
         _configuration.EnvVars = provider;
     }
 


### PR DESCRIPTION
This PR prevents a [NullReferenceException](https://learn.microsoft.com/en-us/dotnet/api/system.nullreferenceexception).