### PR TITLE
fix: Add null check to SetEnvironmentVariablesProvider method

### DIFF
--- a/src/Parser/EnvParser.ConfigurationMethods.cs
+++ b/src/Parser/EnvParser.ConfigurationMethods.cs
@@ -107,6 +107,7 @@ public partial class EnvParser
     /// <inheritdoc />
     public IEnvParser SetEnvironmentVariablesProvider(IEnvironmentVariablesProvider provider)
     {
+        ThrowHelper.ThrowIfNull(provider, nameof(provider));
         _configuration.EnvVars = provider;
         return this;
     }

--- a/src/Parser/IEnvParser.cs
+++ b/src/Parser/IEnvParser.cs
@@ -120,5 +120,6 @@ public interface IEnvParser
     /// </summary>
     /// <param name="provider">The custom environment variables provider.</param>
     /// <returns>An instance implementing the fluent interface.</returns>
+    /// <exception cref="ArgumentNullException"><c>provider</c> is <c>null</c>.</exception> 
     IEnvParser SetEnvironmentVariablesProvider(IEnvironmentVariablesProvider provider);
 }


### PR DESCRIPTION
This PR prevents a [NullReferenceException](https://learn.microsoft.com/en-us/dotnet/api/system.nullreferenceexception).