### PR TITLE
Fix base directory resolution for custom hosting environments

### DIFF
--- a/src/Loader/EnvLoader.HelperMethods.cs
+++ b/src/Loader/EnvLoader.HelperMethods.cs
@@ -72,7 +72,7 @@ public partial class EnvLoader
             envFileName = Path.GetFileName(envFileName);
         }
         else
-            path = AppContext.BaseDirectory;
+            path = PathResolver.BaseDirectory;
 
         for (var directoryInfo = new DirectoryInfo(path);
             directoryInfo is not null;

--- a/src/Loader/PathResolver.cs
+++ b/src/Loader/PathResolver.cs
@@ -1,0 +1,18 @@
+﻿namespace DotEnv.Core;
+
+internal class PathResolver
+{
+    public static string BaseDirectory
+    {
+        get
+        {
+            // AppContext.BaseDirectory may not be available in all hosting
+            // environments (e.g. SampSharp/open.mp). Fall back to the current
+            // working directory when necessary.
+            if (!string.IsNullOrWhiteSpace(AppContext.BaseDirectory))
+                return AppContext.BaseDirectory;
+
+            return Directory.GetCurrentDirectory();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This change introduces a `PathResolver` utility to centralize base directory resolution.

Previously, DotEnv.Core relied directly on `AppContext.BaseDirectory` when searching for `.env` files. While this works in most .NET hosting scenarios, it does not behave reliably under SampSharp/open.mp hosting.

The new implementation falls back to `Directory.GetCurrentDirectory()` when `AppContext.BaseDirectory` is unavailable, providing a more resilient path resolution strategy.

## Motivation

While migrating a game mode to [SampSharp.OpenMp.Entities](https://github.com/ikkentim/SampSharp), `.env` files could not be located correctly because `AppContext.BaseDirectory` was not available as expected.

According to SampSharp maintainer Tim Potze:

> Due to technical limitations of dotnet it's not possible to set the AppContext.BaseDirectory.

As a result, libraries that assume `AppContext.BaseDirectory` is always available may fail in custom hosting environments.

## Changes

* Added `PathResolver` utility class.
* Centralized base directory resolution logic.
* Added fallback to `Directory.GetCurrentDirectory()`.
* Replaced direct usages of `AppContext.BaseDirectory` with `PathResolver.BaseDirectory`.